### PR TITLE
Expor o log através do helper local

### DIFF
--- a/README-GTM-REFERENCE.md
+++ b/README-GTM-REFERENCE.md
@@ -319,6 +319,31 @@ analyticsHelper.safeFn('Nome da Tag', function (helper) {
 });
 ```
 
+#### log(type, message, object)
+Um wrapper ao redor do Console nativo. Criado para garantir que execute apenas durante Debug Mode e apenas se console[type] existir.
+
+##### Argumentos
+* `type` Tipo de console a ser realizado. Pode ser qualquer tipo suportado pelo console: `log`, `warn`, `error`, `table`, `group`...
+
+* `message` Texto a ser enviado para o console.
+
+* `object` (opcional): Qualquer objeto com mais detalhes do que deve ser enviado para o método escolhido.
+
+##### Retorno
+* **undefined**: Nenhum retorno é enviado ou deverá ser esperado após a execução desta função.
+
+##### Exemplo de código
+```javascript
+analyticsHelper.safeFn('Nome da Tag', function (helper) {
+  helper.on('mousedown', '.button', function () {
+    if (helper.wrap(this).hasClass('myClass')) {
+      helper.event('MinhaCategoria', 'MinhaAcao', 'MeuRotulo');
+    } else {
+      helper.log('log', 'Classe "myClass" não encontrada');
+    }
+  });
+});
+```
 #### matches(selector, reduce)
 Função que verifica se o elemento HTML confere com o seletor.
 

--- a/gtm/modules/localHelperFactory.js
+++ b/gtm/modules/localHelperFactory.js
@@ -68,6 +68,7 @@
       id: conf.id,
       args: conf.args,
       fn: fn,
+      log: log,
       _event: conf.event,
       _selector: conf.selector
     };


### PR DESCRIPTION
A função log, atualmente utilizada apenas internamente e apenas quando em debug, foi exposta no helper local.